### PR TITLE
adding the NYTimes logo to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<img src="https://user-images.githubusercontent.com/395641/77785874-37cc4b80-7033-11ea-8bf2-c4c7f2c45acf.png" width="200" alt="The New York Times Logo" />
+
 # Coronavirus (Covid-19) Data in the United States
 
 [ [U.S. State-Level Data](us-states.csv) | [U.S. County-Level Data](us-counties.csv) ]


### PR DESCRIPTION
Making it more clear (visually) that this is a NYTimes repo by adding the NYT logo to the top of the readme file. :)

Note — I pasted the image into an Issue to upload the image to GitHub and used that image path in the `<img>` tag.