### PR TITLE
Fix D.C. data

### DIFF
--- a/us-counties.csv
+++ b/us-counties.csv
@@ -22047,7 +22047,7 @@ date,county,state,fips,cases,deaths
 2020-03-31,Kent,Delaware,10001,34,2
 2020-03-31,New Castle,Delaware,10003,197,6
 2020-03-31,Sussex,Delaware,10005,88,2
-2020-03-31,District of Columbia,District of Columbia,11001,495,9
+2020-03-31,District of Columbia,District of Columbia,11001,586,11
 2020-03-31,Alachua,Florida,12001,87,0
 2020-03-31,Baker,Florida,12003,9,0
 2020-03-31,Bay,Florida,12005,8,0
@@ -24219,7 +24219,7 @@ date,county,state,fips,cases,deaths
 2020-04-01,Kent,Delaware,10001,41,2
 2020-04-01,New Castle,Delaware,10003,226,6
 2020-04-01,Sussex,Delaware,10005,101,3
-2020-04-01,District of Columbia,District of Columbia,11001,586,11
+2020-04-01,District of Columbia,District of Columbia,11001,653,12
 2020-04-01,Alachua,Florida,12001,92,0
 2020-04-01,Baker,Florida,12003,9,0
 2020-04-01,Bay,Florida,12005,13,0
@@ -26459,7 +26459,7 @@ date,county,state,fips,cases,deaths
 2020-04-02,Kent,Delaware,10001,43,2
 2020-04-02,New Castle,Delaware,10003,245,7
 2020-04-02,Sussex,Delaware,10005,105,3
-2020-04-02,District of Columbia,District of Columbia,11001,653,12
+2020-04-02,District of Columbia,District of Columbia,11001,757,15
 2020-04-02,Alachua,Florida,12001,95,0
 2020-04-02,Baker,Florida,12003,11,0
 2020-04-02,Bay,Florida,12005,15,0
@@ -28756,7 +28756,7 @@ date,county,state,fips,cases,deaths
 2020-04-03,Kent,Delaware,10001,54,2
 2020-04-03,New Castle,Delaware,10003,279,9
 2020-04-03,Sussex,Delaware,10005,117,3
-2020-04-03,District of Columbia,District of Columbia,11001,757,15
+2020-04-03,District of Columbia,District of Columbia,11001,902,21
 2020-04-03,Alachua,Florida,12001,110,0
 2020-04-03,Baker,Florida,12003,11,0
 2020-04-03,Bay,Florida,12005,18,0
@@ -31116,7 +31116,7 @@ date,county,state,fips,cases,deaths
 2020-04-04,Kent,Delaware,10001,68,2
 2020-04-04,New Castle,Delaware,10003,400,9
 2020-04-04,Sussex,Delaware,10005,125,3
-2020-04-04,District of Columbia,District of Columbia,11001,902,21
+2020-04-04,District of Columbia,District of Columbia,11001,998,22
 2020-04-04,Alachua,Florida,12001,116,0
 2020-04-04,Baker,Florida,12003,11,0
 2020-04-04,Bay,Florida,12005,23,1
@@ -33523,7 +33523,7 @@ date,county,state,fips,cases,deaths
 2020-04-05,Kent,Delaware,10001,86,2
 2020-04-05,New Castle,Delaware,10003,436,9
 2020-04-05,Sussex,Delaware,10005,151,3
-2020-04-05,District of Columbia,District of Columbia,11001,998,22
+2020-04-05,District of Columbia,District of Columbia,11001,1097,24
 2020-04-05,Alachua,Florida,12001,123,0
 2020-04-05,Baker,Florida,12003,12,0
 2020-04-05,Bay,Florida,12005,24,1
@@ -35971,7 +35971,7 @@ date,county,state,fips,cases,deaths
 2020-04-06,Kent,Delaware,10001,128,3
 2020-04-06,New Castle,Delaware,10003,496,9
 2020-04-06,Sussex,Delaware,10005,159,3
-2020-04-06,District of Columbia,District of Columbia,11001,1097,24
+2020-04-06,District of Columbia,District of Columbia,11001,1211,22
 2020-04-06,Alachua,Florida,12001,133,0
 2020-04-06,Baker,Florida,12003,13,0
 2020-04-06,Bay,Florida,12005,24,1
@@ -38460,7 +38460,7 @@ date,county,state,fips,cases,deaths
 2020-04-07,Kent,Delaware,10001,147,3
 2020-04-07,New Castle,Delaware,10003,571,9
 2020-04-07,Sussex,Delaware,10005,210,4
-2020-04-07,District of Columbia,District of Columbia,11001,1211,22
+2020-04-07,District of Columbia,District of Columbia,11001,1440,27
 2020-04-07,Alachua,Florida,12001,139,0
 2020-04-07,Baker,Florida,12003,15,1
 2020-04-07,Bay,Florida,12005,25,1
@@ -41001,7 +41001,7 @@ date,county,state,fips,cases,deaths
 2020-04-08,Kent,Delaware,10001,201,3
 2020-04-08,New Castle,Delaware,10003,636,11
 2020-04-08,Sussex,Delaware,10005,279,5
-2020-04-08,District of Columbia,District of Columbia,11001,1440,27
+2020-04-08,District of Columbia,District of Columbia,11001,1523,32
 2020-04-08,Alachua,Florida,12001,144,0
 2020-04-08,Baker,Florida,12003,15,1
 2020-04-08,Bay,Florida,12005,28,1
@@ -43567,7 +43567,7 @@ date,county,state,fips,cases,deaths
 2020-04-09,Kent,Delaware,10001,214,3
 2020-04-09,New Castle,Delaware,10003,701,13
 2020-04-09,Sussex,Delaware,10005,294,7
-2020-04-09,District of Columbia,District of Columbia,11001,1523,32
+2020-04-09,District of Columbia,District of Columbia,11001,1660,38
 2020-04-09,Alachua,Florida,12001,154,0
 2020-04-09,Baker,Florida,12003,16,2
 2020-04-09,Bay,Florida,12005,34,1
@@ -46165,7 +46165,7 @@ date,county,state,fips,cases,deaths
 2020-04-10,New Castle,Delaware,10003,751,19
 2020-04-10,Sussex,Delaware,10005,336,10
 2020-04-10,Unknown,Delaware,,9,0
-2020-04-10,District of Columbia,District of Columbia,11001,1660,38
+2020-04-10,District of Columbia,District of Columbia,11001,1778,47
 2020-04-10,Alachua,Florida,12001,167,0
 2020-04-10,Baker,Florida,12003,16,2
 2020-04-10,Bay,Florida,12005,36,1
@@ -48795,7 +48795,7 @@ date,county,state,fips,cases,deaths
 2020-04-11,New Castle,Delaware,10003,807,19
 2020-04-11,Sussex,Delaware,10005,404,10
 2020-04-11,Unknown,Delaware,,13,0
-2020-04-11,District of Columbia,District of Columbia,11001,1778,47
+2020-04-11,District of Columbia,District of Columbia,11001,1875,50
 2020-04-11,Alachua,Florida,12001,174,0
 2020-04-11,Baker,Florida,12003,17,2
 2020-04-11,Bay,Florida,12005,36,1
@@ -51455,7 +51455,7 @@ date,county,state,fips,cases,deaths
 2020-04-12,Kent,Delaware,10001,281,4
 2020-04-12,New Castle,Delaware,10003,880,19
 2020-04-12,Sussex,Delaware,10005,464,12
-2020-04-12,District of Columbia,District of Columbia,11001,1875,50
+2020-04-12,District of Columbia,District of Columbia,11001,1955,52
 2020-04-12,Alachua,Florida,12001,183,0
 2020-04-12,Baker,Florida,12003,17,2
 2020-04-12,Bay,Florida,12005,37,1
@@ -54136,7 +54136,7 @@ date,county,state,fips,cases,deaths
 2020-04-13,New Castle,Delaware,10003,919,20
 2020-04-13,Sussex,Delaware,10005,551,15
 2020-04-13,Unknown,Delaware,,3,0
-2020-04-13,District of Columbia,District of Columbia,11001,1955,52
+2020-04-13,District of Columbia,District of Columbia,11001,2058,67
 2020-04-13,Alachua,Florida,12001,187,0
 2020-04-13,Baker,Florida,12003,17,2
 2020-04-13,Bay,Florida,12005,39,1
@@ -56829,7 +56829,7 @@ date,county,state,fips,cases,deaths
 2020-04-14,New Castle,Delaware,10003,947,20
 2020-04-14,Sussex,Delaware,10005,639,16
 2020-04-14,Unknown,Delaware,,11,0
-2020-04-14,District of Columbia,District of Columbia,11001,1875,50
+2020-04-14,District of Columbia,District of Columbia,11001,2197,72
 2020-04-14,Alachua,Florida,12001,195,0
 2020-04-14,Baker,Florida,12003,17,2
 2020-04-14,Bay,Florida,12005,38,2


### PR DESCRIPTION
So I noticed several discrepancies in D.C. data that I have fixed.

* Starting March 31, the data that was in the repo has actually been *for the day before*. I have shifted the data after this back by a day.
* April 14's data was incorrect and has been fixed.

The source for all my changes is https://coronavirus.dc.gov/page/coronavirus-data, the D.C. government's official data page. April 5 is missing from this page, but I was able to find data for it on [Mayor Muriel Bowser's Twitter](https://twitter.com/MayorBowser/status/1247182500688007177). I'm not sure who maintains the D.C. data specifically, but I would suggest sticking to the first link I gave.