### PR TITLE
Added "Open in Colab" button for dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Coronavirus (Covid-19) Data in the United States
 
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/rchurt/rchurt.github.io/blob/master/covid_19_data.ipynb)
+
 **NEW:** We are publishing the data behind our [excess deaths tracker](https://www.nytimes.com/interactive/2020/04/21/world/coronavirus-missing-deaths.html) in order to provide researchers and the public with a better record of the true toll of the pandemic. This data is compiled from official national and municipal data for 24 countries. See the data and documentation in the [excess-deaths/](excess-deaths/) directory.
 
 ---


### PR DESCRIPTION
Just putting this out there as a suggestion: it could be useful to have a button at the top of the README that will open the dataset in an environment where users can interact with it immediately--all with a single click.

In the example here, this Jupyter Notebook will import the dataset into a Pandas DataFrame so it can be manipulated in Python. It's implemented in Google Colab, which allows users to run it on a virtual machine through their browsers, with no need to install any kernel or packages locally.

If you decide to do this, it certainly doesn't have to be using my notebook (in fact I would suggest that you make your own notebook, copying as much or little from mine as you want, and put that in the main directory of this repo, linking to it in this README). Please let me know if you'd like any help with this or have any questions about why this would be valuable to users.